### PR TITLE
Testing fixes

### DIFF
--- a/src/App.cy.tsx
+++ b/src/App.cy.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import App from "./App";
 import { addDaysToDate } from "./utils/dateUtils";
+import { vurdererHeadingText } from "./commonTexts";
 
 describe("<App />", () => {
   it("Displays linkpanel for forhåndsvarsel if journalpostid is present", () => {
@@ -21,12 +22,12 @@ describe("<App />", () => {
       fristDato: addDaysToDate(new Date(), 14).toISOString(),
     });
 
-    cy.get("#mikrofrontend__panel").contains("NAV vurderer å stanse sykepengene dine");
+    cy.get("#mikrofrontend__panel").contains(vurdererHeadingText);
   });
 
   it("Displays under arbeid if status ny", () => {
     cy.mountWithStubs(<App />, { status: "NY" });
 
-    cy.get("#mikrofrontend__linkPanel").contains("NAV vurderer aktivitetsplikten din");
+    cy.get("#mikrofrontend__linkPanel").contains(vurdererHeadingText);
   });
 });

--- a/src/App.cy.tsx
+++ b/src/App.cy.tsx
@@ -11,7 +11,7 @@ describe("<App />", () => {
       fristDato: addDaysToDate(new Date(), 14).toISOString(),
     });
 
-    cy.get("#mikrofrontend__linkPanel").contains("Mulig stans av sykepenger");
+    cy.get("#mikrofrontend__linkPanel").contains("NAV vurderer å stanse sykepengene dine");
   });
 
   it("Displays regular panel for forhåndsvarsel if no journalpostid is present", () => {
@@ -21,7 +21,7 @@ describe("<App />", () => {
       fristDato: addDaysToDate(new Date(), 14).toISOString(),
     });
 
-    cy.get("#mikrofrontend__panel").contains("Mulig stans av sykepenger");
+    cy.get("#mikrofrontend__panel").contains("NAV vurderer å stanse sykepengene dine");
   });
 
   it("Displays under arbeid if status ny", () => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ function App() {
   if (data) {
     switch (data.status) {
       case "NY":
+      case "AVVENTER":
         return <UnderArbeidPanel />;
       case "UNNTAK":
         return <UnntakPanel arsak={data.arsaker[0]} sistVurdert={data.sistVurdert} />;

--- a/src/commonTexts.ts
+++ b/src/commonTexts.ts
@@ -1,0 +1,2 @@
+export const harVurdertHeadingText = "NAV har vurdert aktivitetsplikten din";
+export const vurdererHeadingText = "NAV vurderer aktivitetsplikten din";

--- a/src/components/panels/ForhaandsvarselPanel.tsx
+++ b/src/components/panels/ForhaandsvarselPanel.tsx
@@ -12,7 +12,7 @@ interface Props {
 export const ForhaandsvarselPanel = ({ journalpostId, fristDato }: Props) => {
   const tagInfo: TagMeta | undefined = fristDato
     ? {
-        variant: "warning-moderate",
+        variant: new Date() > new Date(fristDato) ? "error-moderate" : "warning-moderate",
         text: `Svarfrist: ${getShortDateFormat(fristDato)}`,
       }
     : undefined;

--- a/src/components/panels/ForhaandsvarselPanel.tsx
+++ b/src/components/panels/ForhaandsvarselPanel.tsx
@@ -3,6 +3,7 @@ import { MikrofrontendLinkPanel } from "./common/MikrofrontendLinkPanel";
 import { journalpostPageUrl } from "../../api/urls";
 import { MikrofrontendPanel, TagMeta } from "./common/MikrofrontendPanel";
 import { getShortDateFormat } from "../../utils/dateUtils";
+import { vurdererHeadingText } from "../../commonTexts";
 
 interface Props {
   journalpostId?: string;
@@ -21,7 +22,7 @@ export const ForhaandsvarselPanel = ({ journalpostId, fristDato }: Props) => {
     return (
       //Skal normalt ikke skje, men for å ha en fallback dersom journalføring gikk galt eller noe.
       <MikrofrontendPanel
-        headingText="NAV vurderer aktivitetsplikten din"
+        headingText={vurdererHeadingText}
         bodyText={`NAV vurderer å stanse sykepengene dine. Du vil motta et brev om dette i Mine Saker`}
         alertStyle="warning"
         tag={tagInfo}
@@ -32,7 +33,7 @@ export const ForhaandsvarselPanel = ({ journalpostId, fristDato }: Props) => {
   return (
     <MikrofrontendLinkPanel
       href={journalpostPageUrl(journalpostId)}
-      headingText="NAV vurderer aktivitetsplikten din"
+      headingText={vurdererHeadingText}
       bodyText="NAV vurderer å stanse sykepengene dine"
       alertStyle="warning"
       tag={tagInfo}

--- a/src/components/panels/ForhaandsvarselPanel.tsx
+++ b/src/components/panels/ForhaandsvarselPanel.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { MikrofrontendLinkPanel } from "./common/MikrofrontendLinkPanel";
 import { journalpostPageUrl } from "../../api/urls";
-import { MikrofrontendPanel } from "./common/MikrofrontendPanel";
+import { MikrofrontendPanel, TagMeta } from "./common/MikrofrontendPanel";
 import { getShortDateFormat } from "../../utils/dateUtils";
 
 interface Props {
@@ -10,17 +10,21 @@ interface Props {
 }
 
 export const ForhaandsvarselPanel = ({ journalpostId, fristDato }: Props) => {
+  const tagInfo: TagMeta | undefined = fristDato
+    ? {
+        variant: "warning-moderate",
+        text: `Svarfrist: ${getShortDateFormat(fristDato)}`,
+      }
+    : undefined;
+
   if (!journalpostId) {
     return (
       //Skal normalt ikke skje, men for å ha en fallback dersom journalføring gikk galt eller noe.
       <MikrofrontendPanel
-        headingText="Mulig stans av sykepenger"
+        headingText="NAV vurderer aktivitetsplikten din"
         bodyText={`NAV vurderer å stanse sykepengene dine. Du vil motta et brev om dette i Mine Saker`}
-        alertStyle="error"
-        tag={{
-          variant: "error-moderate",
-          text: `Svarfrist: ${getShortDateFormat(fristDato)}`,
-        }}
+        alertStyle="warning"
+        tag={tagInfo}
       />
     );
   }
@@ -28,13 +32,10 @@ export const ForhaandsvarselPanel = ({ journalpostId, fristDato }: Props) => {
   return (
     <MikrofrontendLinkPanel
       href={journalpostPageUrl(journalpostId)}
-      headingText="Mulig stans av sykepenger"
+      headingText="NAV vurderer aktivitetsplikten din"
       bodyText="NAV vurderer å stanse sykepengene dine"
-      alertStyle="error"
-      tag={{
-        variant: "error-moderate",
-        text: `Svarfrist: ${getShortDateFormat(fristDato)}`,
-      }}
+      alertStyle="warning"
+      tag={tagInfo}
     />
   );
 };

--- a/src/components/panels/IkkeAktuellPanel.tsx
+++ b/src/components/panels/IkkeAktuellPanel.tsx
@@ -9,7 +9,7 @@ interface Props {
 export const IkkeAktuellPanel = ({ sistVurdert }: Props) => {
   return (
     <MikrofrontendPanel
-      headingText="Aktivitetsplikten er ikke relevant for deg"
+      headingText="NAV har vurdert aktivitetsplikten din"
       bodyText="NAV vurderer at aktivitetsplikten ikke er aktuell for deg"
       alertStyle="info"
       tag={{

--- a/src/components/panels/IkkeAktuellPanel.tsx
+++ b/src/components/panels/IkkeAktuellPanel.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { MikrofrontendPanel } from "./common/MikrofrontendPanel";
 import { getShortDateFormat } from "../../utils/dateUtils";
+import { harVurdertHeadingText } from "../../commonTexts";
 
 interface Props {
   sistVurdert: string;
@@ -9,7 +10,7 @@ interface Props {
 export const IkkeAktuellPanel = ({ sistVurdert }: Props) => {
   return (
     <MikrofrontendPanel
-      headingText="NAV har vurdert aktivitetsplikten din"
+      headingText={harVurdertHeadingText}
       bodyText="NAV vurderer at aktivitetsplikten ikke er aktuell for deg"
       alertStyle="info"
       tag={{

--- a/src/components/panels/OppfyltPanel.tsx
+++ b/src/components/panels/OppfyltPanel.tsx
@@ -24,7 +24,7 @@ export const OppfyltPanel = ({ arsak, sistVurdert }: Props) => {
 
   return (
     <MikrofrontendPanel
-      headingText="Aktivitetsplikten er oppfylt"
+      headingText="NAV har vurdert aktivitetsplikten din"
       bodyText={begrunnelseText}
       alertStyle="success"
       tag={{

--- a/src/components/panels/OppfyltPanel.tsx
+++ b/src/components/panels/OppfyltPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { OppfyltArsaker } from "../../schema/aktivitetskravVurderingSchema";
 import { MikrofrontendPanel } from "./common/MikrofrontendPanel";
 import { getShortDateFormat } from "../../utils/dateUtils";
+import { harVurdertHeadingText } from "../../commonTexts";
 
 interface Props {
   arsak: OppfyltArsaker;
@@ -24,7 +25,7 @@ export const OppfyltPanel = ({ arsak, sistVurdert }: Props) => {
 
   return (
     <MikrofrontendPanel
-      headingText="NAV har vurdert aktivitetsplikten din"
+      headingText={harVurdertHeadingText}
       bodyText={begrunnelseText}
       alertStyle="success"
       tag={{

--- a/src/components/panels/UnderArbeidPanel.tsx
+++ b/src/components/panels/UnderArbeidPanel.tsx
@@ -1,10 +1,11 @@
 import React from "react";
 import { MikrofrontendLinkPanel } from "./common/MikrofrontendLinkPanel";
+import { vurdererHeadingText } from "../../commonTexts";
 
 export const UnderArbeidPanel = () => {
   return (
     <MikrofrontendLinkPanel
-      headingText="NAV vurderer aktivitetsplikten din"
+      headingText={vurdererHeadingText}
       bodyText="Les mer om aktivitetsplikten og hva den betyr for deg"
       alertStyle="info"
     />

--- a/src/components/panels/UnntakPanel.tsx
+++ b/src/components/panels/UnntakPanel.tsx
@@ -24,7 +24,7 @@ export const UnntakPanel = ({ arsak, sistVurdert }: Props) => {
 
   return (
     <MikrofrontendPanel
-      headingText="Unntak fra aktivitetsplikten"
+      headingText="NAV har vurdert aktivitetsplikten din"
       bodyText={begrunnelseText}
       alertStyle="success"
       tag={{

--- a/src/components/panels/UnntakPanel.tsx
+++ b/src/components/panels/UnntakPanel.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { MikrofrontendPanel } from "./common/MikrofrontendPanel";
 import { UnntakArsaker } from "../../schema/aktivitetskravVurderingSchema";
 import { getShortDateFormat } from "../../utils/dateUtils";
+import { harVurdertHeadingText } from "../../commonTexts";
 
 interface Props {
   arsak: UnntakArsaker;
@@ -24,7 +25,7 @@ export const UnntakPanel = ({ arsak, sistVurdert }: Props) => {
 
   return (
     <MikrofrontendPanel
-      headingText="NAV har vurdert aktivitetsplikten din"
+      headingText={harVurdertHeadingText}
       bodyText={begrunnelseText}
       alertStyle="success"
       tag={{

--- a/src/components/panels/common/PanelComponents.tsx
+++ b/src/components/panels/common/PanelComponents.tsx
@@ -98,7 +98,7 @@ export const MainContentRow = styled.div`
 `;
 
 export const MainContentText = styled(Heading)`
-  font-weight: var(--a-font-weight-regular);
+  font-weight: var(--a-font-weight-regular) !important;
 `;
 
 export const ChevronSection = styled.div`

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,6 @@ import fixtures from "./fixtures";
 
 export const handlers = [
   rest.get("*/api/aktivitetsplikt", (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(fixtures.nyKandidatVurdering));
+    return res(ctx.status(200), ctx.json(fixtures.forhaandsvarselVurdering));
   }),
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -3,6 +3,6 @@ import fixtures from "./fixtures";
 
 export const handlers = [
   rest.get("*/api/aktivitetsplikt", (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(fixtures.forhaandsvarselVurdering));
+    return res(ctx.status(200), ctx.json(fixtures.unntakVurdering));
   }),
 ];

--- a/src/schema/aktivitetskravVurderingSchema.ts
+++ b/src/schema/aktivitetskravVurderingSchema.ts
@@ -23,6 +23,9 @@ export const aktivitetskravVurderingSchema = union([
     status: z.literal("NY"),
   }),
   object({
+    status: z.literal("AVVENTER"),
+  }),
+  object({
     status: z.literal("FORHANDSVARSEL"),
     journalpostId: string().optional(),
     sistVurdert: string().datetime(),


### PR DESCRIPTION
- Status "avventer" viser nå samme status som "ny"
- Endrer header på alle visninger til enten "NAV har vurdert aktivitetsplikten din" eller "NAV vurderer aktivitetsplikten din"
- Skjuler frist dersom den ikke finnes enda
- Viser gul frist dersom i fremtiden, rød dersom passert